### PR TITLE
Make it possible to guarantee that final DATA frame is marked end-of-stream

### DIFF
--- a/Network/HTTP/Semantics/FillBuf.hs
+++ b/Network/HTTP/Semantics/FillBuf.hs
@@ -9,6 +9,7 @@ module Network.HTTP.Semantics.FillBuf (
     DynaNext,
     BytesFilled,
     StreamingChunk (..),
+    CleanupStream,
     fillBuilderBodyGetNext,
     fillFileBodyGetNext,
     fillStreamBodyGetNext,
@@ -47,9 +48,18 @@ data Leftover
 ----------------------------------------------------------------
 
 data StreamingChunk
-    = StreamingFinished (IO ())
-    | StreamingFlush
-    | StreamingBuilder Builder
+    = -- | Indicate that the stream is finished
+      StreamingFinished CleanupStream
+    | -- | Flush the stream
+      --
+      -- This will cause the write buffer to be written to the network socket,
+      -- without waiting for more data.
+      StreamingFlush
+    | -- | Construct a DATA frame
+      StreamingBuilder Builder
+
+-- | Action to run prior to terminating the stream
+type CleanupStream = IO ()
 
 ----------------------------------------------------------------
 

--- a/Network/HTTP/Semantics/Types.hs
+++ b/Network/HTTP/Semantics/Types.hs
@@ -76,6 +76,12 @@ data OutBodyIface = OutBodyIface
     -- ^ Unmask exceptions in the thread spawned for the request body
     , outBodyPush :: Builder -> IO ()
     -- ^ Push a new chunk
+    , outBodyPushFinal :: Builder -> IO ()
+    -- ^ Push the final chunk
+    --
+    -- Using this function instead of 'outBodyPush' can be used to guarantee that the final
+    -- HTTP2 DATA frame is marked end-of-stream; with 'outBodyPush' it may happen that
+    -- an additional empty DATA frame is used for this purpose.
     , outBodyFlush :: IO ()
     -- ^ Flush
     }

--- a/Network/HTTP/Semantics/Types.hs
+++ b/Network/HTTP/Semantics/Types.hs
@@ -8,6 +8,7 @@ module Network.HTTP.Semantics.Types (
     -- * Request/response as output
     OutObj (..),
     OutBody (..),
+    OutBodyIface (..),
 
     -- * Trailers maker
     TrailersMaker,
@@ -66,10 +67,18 @@ data OutBody
       --
       -- TODO: The analogous change for the server-side would be to provide a similar
       -- @unmask@ callback as the first argument in the 'Server' type alias.
-      OutBodyStreamingUnmask
-        ((forall x. IO x -> IO x) -> (Builder -> IO ()) -> IO () -> IO ())
+      OutBodyStreamingUnmask (OutBodyIface -> IO ())
     | OutBodyBuilder Builder
     | OutBodyFile FileSpec
+
+data OutBodyIface = OutBodyIface
+    { outBodyUnmask :: (forall x. IO x -> IO x)
+    -- ^ Unmask exceptions in the thread spawned for the request body
+    , outBodyPush :: Builder -> IO ()
+    -- ^ Push a new chunk
+    , outBodyFlush :: IO ()
+    -- ^ Flush
+    }
 
 -- | Input object
 data InpObj = InpObj


### PR DESCRIPTION
Prior to this PR, when the thread constructing the streaming body of a request (that is, the argument to `requestStreaming` or `requestStreamingUnmask`) terminated without calling `flush`, the final DATA frame would _usually_ be marked as end-of-stream, but there was no _guarantee_ that this would happen. Specifically, this depended on whether the `StreamingFinished` chunk would be enqueued _before_ some other thread interrupted (perhaps because of a window update):

https://github.com/kazu-yamamoto/http2/blob/398a5c5284421399a6b91a12734a2293a78c0a1b/Network/HTTP2/Client/Run.hs#L206-L211

If this chunk happened to be enqueued a bit later, the result would be that the constructed DATA frame would _not_ be marked as end-of-stream, but instead the stream would terminate with a separate _empty_ data frame. Unfortunately, this confuses some servers, so we need a way to have more control over this.

This PR (along with a companion small PR for `http2`) achieves this goal in a few steps:

* First, we introduce `requestStreamingIface`. I was worried that we'd end up with a whole family of functions `requestStreaming`, `requestStreamingUnmask`, `requestStreamingThisThatOrTheOther`; so to avoid this, `requestStreamingIface` instead provides the callback with a record of functions, which we can add new features to at will without breaking backwards compatibility and without having to invent new names.
* Then some refactoring: we document `StreamingChunk`, split `fillBufBuilder` (see comments inline for the commits), simplify `DynaNext` (again, comments in the commit), and refactor `fillStreamBodyGetNext` (see commit). These changes just pave the way for the "real" change in the next commit.
* We add an argument to `StreamingBuilder` to indicate that this `Builder` is the end-of-stream. This is the direct send equivalent of what we did for receive in #1.
* Finally, we add `outBodyPushFinal` to `OutBodyIface`, which can then be populated in `http2`, making use of the new argument to `StreamingBuilder`.