### PR TITLE
Avoid buffer overflow in `fillBufBuilderOne`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.1.2
+
+* Avoid buffer overflow in fillBufBuilderOne
+  [#3](https://github.com/kazu-yamamoto/http-semantics/pull/4)
+
 ## 0.1.1
 
 * Avoid buffer overflow in runStreamingBuilder

--- a/http-semantics.cabal
+++ b/http-semantics.cabal
@@ -1,6 +1,6 @@
 cabal-version:      >=1.10
 name:               http-semantics
-version:            0.1.1
+version:            0.1.2
 license:            BSD3
 license-file:       LICENSE
 maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>


### PR DESCRIPTION
This is nearly exactly the same fix as my last patch (#3), just for another occurrence of `Data.ByteString.Builder.More`. We haven't seen any issues resulting from this code path ourselves, but it is vulnerable to the same sort of buffer overflow as the previous patch (running a writer in a buffer which might not have enough `room`). 

Sorry I missed this before! I bumped the version and added a ChangeLog entry.