### PR TITLE
Introduce `responseStreamingIface`

### DIFF
--- a/Network/HTTP/Semantics/Client.hs
+++ b/Network/HTTP/Semantics/Client.hs
@@ -120,7 +120,7 @@ requestStreamingIface
     -> RequestHeaders
     -> (OutBodyIface -> IO ())
     -> Request
-requestStreamingIface m p hdr strmbdy = Request $ OutObj hdr' (OutBodyStreamingUnmask strmbdy) defaultTrailersMaker
+requestStreamingIface m p hdr strmbdy = Request $ OutObj hdr' (OutBodyStreamingIface strmbdy) defaultTrailersMaker
   where
     hdr' = addHeaders m p hdr
 

--- a/Network/HTTP/Semantics/Server.hs
+++ b/Network/HTTP/Semantics/Server.hs
@@ -33,6 +33,10 @@ module Network.HTTP.Semantics.Server (
     responseStreaming,
     responseBuilder,
 
+    -- ** Generalized streaming interface
+    OutBodyIface(..),
+    responseStreamingIface,
+
     -- ** Accessing response
     responseBodySize,
 
@@ -165,6 +169,16 @@ responseStreaming
     -> ((Builder -> IO ()) -> IO () -> IO ())
     -> Response
 responseStreaming st hdr strmbdy = Response $ OutObj hdr' (OutBodyStreaming strmbdy) defaultTrailersMaker
+  where
+    hdr' = setStatus st hdr
+
+-- | Generalization of 'responseStreaming'.
+responseStreamingIface
+    :: H.Status
+    -> H.ResponseHeaders
+    -> (OutBodyIface -> IO ())
+    -> Response
+responseStreamingIface st hdr strmbdy = Response $ OutObj hdr' (OutBodyStreamingIface strmbdy) defaultTrailersMaker
   where
     hdr' = setStatus st hdr
 


### PR DESCRIPTION
Prior to this commit, when a server finished streaming, it had no way of indicating this (i.e. it has no way of setting the second argument to `StreamingBuilder`). As a result, `http2` would emit a final DATA frame when it finished the processing the builder along with a subsequent *empty* data frame when processing `StreamingFinished`. This results in an empty data frame at the end of every response. If the volume of responses is high, this even triggers the `emptyFrameRateLimit` in `http2`.