### PR TITLE
Close file on time

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for http-semantics
 
+## 0.3.0
+
+* Breaking change: fillFileBodyGetNext takes Sentinel instead of
+  IO () to close files on time.
+
 ## 0.2.1
 
 * Add outBodyCancel to OutBodyIface

--- a/http-semantics.cabal
+++ b/http-semantics.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            http-semantics
-version:         0.2.1
+version:         0.3.0
 license:         BSD-3-Clause
 license-file:    LICENSE
 maintainer:      Kazu Yamamoto <kazu@iij.ad.jp>


### PR DESCRIPTION
I don't remember correctly why I used a timer to close a file instead of closing a file on time.
The original code was placed in Warp deeply so I guess that I did not notice the on-time approach is possible.
Currently I believe that closing a file on time has no side-effect and is more elegant than the timer approach.
Unfortunately, this introduces a breaking change.

@edsko What do you think?