### PR TITLE
TrailersMaker refactor

### DIFF
--- a/Network/HTTP/Semantics/Client.hs
+++ b/Network/HTTP/Semantics/Client.hs
@@ -21,8 +21,7 @@ module Network.HTTP.Semantics.Client (
     requestStreamingIface,
 
     -- ** Trailers maker
-    TrailersMaker,
-    NextTrailersMaker (..),
+    TrailersMaker (..),
     defaultTrailersMaker,
     setRequestTrailersMaker,
 

--- a/Network/HTTP/Semantics/Server.hs
+++ b/Network/HTTP/Semantics/Server.hs
@@ -40,8 +40,7 @@ module Network.HTTP.Semantics.Server (
     responseBodySize,
 
     -- ** Trailers maker
-    TrailersMaker,
-    NextTrailersMaker (..),
+    TrailersMaker (..),
     defaultTrailersMaker,
     setResponseTrailersMaker,
 

--- a/Network/HTTP/Semantics/Trailer.hs
+++ b/Network/HTTP/Semantics/Trailer.hs
@@ -17,35 +17,29 @@ import qualified Network.HTTP.Types as H
 --   > import qualified Crypto.Hash as CH
 --   >
 --   > -- Strictness is important for Context.
---   > trailersMaker :: Context SHA1 -> Maybe ByteString -> IO NextTrailersMaker
---   > trailersMaker ctx Nothing = return $ Trailers [("X-SHA1", sha1)]
+--   > trailersMaker :: Context SHA1 -> TrailersMaker
+--   > trailersMaker ctx = TrailersMaker [("X-SHA1", sha1)] next
 --   >   where
 --   >     !sha1 = C8.pack $ show $ CH.hashFinalize ctx
---   > trailersMaker ctx (Just bs) = return $ NextTrailersMaker $ trailersMaker ctx'
---   >   where
---   >     !ctx' = CH.hashUpdate ctx bs
+--   >     next bs = return trailersMaker ctx'
+--   >       where
+--   >         !ctx' = CH.hashUpdate ctx bs
 --
 --   Usage example:
 --
 --   > let h2rsp = responseFile ...
 --   >     maker = trailersMaker (CH.hashInit :: Context SHA1)
 --   >     h2rsp' = setResponseTrailersMaker h2rsp maker
-type TrailersMaker = Maybe ByteString -> IO NextTrailersMaker
+data TrailersMaker = TrailersMaker [H.Header] (ByteString -> IO TrailersMaker)
 
 -- | TrailersMake to create no trailers.
 defaultTrailersMaker :: TrailersMaker
-defaultTrailersMaker Nothing = return $ Trailers []
-defaultTrailersMaker _ = return $ NextTrailersMaker defaultTrailersMaker
-
--- | Either the next trailers maker or final trailers.
-data NextTrailersMaker
-    = NextTrailersMaker TrailersMaker
-    | Trailers [H.Header]
+defaultTrailersMaker = TrailersMaker [] (\_ -> return defaultTrailersMaker)
 
 ----------------------------------------------------------------
 
 -- | Running trailers-maker.
 --
 -- > bufferIO buf siz $ \bs -> tlrmkr (Just bs)
-runTrailersMaker :: TrailersMaker -> Buffer -> Int -> IO NextTrailersMaker
-runTrailersMaker tlrmkr buf siz = bufferIO buf siz $ \bs -> tlrmkr (Just bs)
+runTrailersMaker :: TrailersMaker -> Buffer -> Int -> IO TrailersMaker
+runTrailersMaker (TrailersMaker _ f) buf siz = bufferIO buf siz $ \bs -> f bs

--- a/Network/HTTP/Semantics/Types.hs
+++ b/Network/HTTP/Semantics/Types.hs
@@ -11,9 +11,8 @@ module Network.HTTP.Semantics.Types (
     OutBodyIface (..),
 
     -- * Trailers maker
-    TrailersMaker,
+    TrailersMaker (..),
     defaultTrailersMaker,
-    NextTrailersMaker (..),
 
     -- * File spec
     FileOffset,


### PR DESCRIPTION
Change TrailersMaker to essentially be two "functions": give new TrailersMaker given a new data chunk, or give trailers if the data is ended.

As seen in a following adoption patch to `http2` package, the TrailersMaker change allows to drop partial matches in a server code. We don't need to rely on a dynamic behaviour where passing `Nothing` should always returned `Trailers` constructor; we can encode that statically in type.

Algebraically: `(A + B) -> (C + D)` is not the same as `(A -> C) + (B -> D)`. The current type for `TrailersMaker` is too lax.

```diff
--- a/Network/HTTP2/H2/Sender.hs
+++ b/Network/HTTP2/H2/Sender.hs
@@ -217,7 +217,7 @@ frameSender
                 datBufSiz = buflim - payloadOff
             curr datBuf (min datBufSiz lim) >>= \case
                 Next datPayloadLen reqflush mnext -> do
-                    NextTrailersMaker tlrmkr' <- runTrailersMaker tlrmkr datBuf datPayloadLen
+                    tlrmkr' <- runTrailersMaker tlrmkr datBuf datPayloadLen
                     fillDataHeader
                         strm
                         off0
@@ -298,7 +298,7 @@ frameSender
             -> Offset
             -> Int
             -> Maybe DynaNext
-            -> (Maybe ByteString -> IO NextTrailersMaker)
+            -> TrailersMaker
             -> Output
             -> Bool
             -> IO (Offset, Maybe Output)
@@ -312,7 +312,7 @@ frameSender
             reqflush = do
                 let buf = confWriteBuffer `plusPtr` off
                 (mtrailers, flag) <- do
-                    Trailers trailers <- tlrmkr Nothing
+                    let TrailersMaker trailers _ = tlrmkr
                     if null trailers
                         then return (Nothing, setEndStream defaultFlags)
                         else return (Just trailers, defaultFlags)
```

cc @edsko 