### PR TITLE
Add auxSendInformational to Aux for sending 1xx informational responses

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for http-semantics
 
+## 0.4.1
+
+* Add `auxSendInformational` to the server `Aux` for sending 1xx informational
+  responses (e.g. 103 Early Hints) ahead of the final response.
+
 ## 0.4.0
 
 * This version is idential to v0.3.1 which includes breaking changes

--- a/Network/HTTP/Semantics/Server.hs
+++ b/Network/HTTP/Semantics/Server.hs
@@ -22,6 +22,7 @@ module Network.HTTP.Semantics.Server (
     auxTimeHandle,
     auxMySockAddr,
     auxPeerSockAddr,
+    auxSendInformational,
 
     -- * Response
     Response,
@@ -82,6 +83,7 @@ defaultAux =
         { auxTimeHandle = T.emptyHandle
         , auxMySockAddr = SockAddrInet 0 0
         , auxPeerSockAddr = SockAddrInet 0 0
+        , auxSendInformational = \_ _ -> return ()
         }
 
 ----------------------------------------------------------------

--- a/Network/HTTP/Semantics/Server/Internal.hs
+++ b/Network/HTTP/Semantics/Server/Internal.hs
@@ -28,4 +28,6 @@ data Aux = Aux
     -- ^ Send an informational (1xx) response, e.g. 103 Early Hints, on this
     --   request's stream before the final response. May be called multiple
     --   times. A no-op in 'defaultAux'.
+    --
+    --   @since 0.4.1
     }

--- a/Network/HTTP/Semantics/Server/Internal.hs
+++ b/Network/HTTP/Semantics/Server/Internal.hs
@@ -4,6 +4,7 @@ module Network.HTTP.Semantics.Server.Internal (
     Aux (..),
 ) where
 
+import qualified Network.HTTP.Types as H
 import Network.Socket (SockAddr)
 import qualified System.TimeManager as T
 
@@ -23,4 +24,8 @@ data Aux = Aux
     -- ^ Local socket address copied from 'Config'.
     , auxPeerSockAddr :: SockAddr
     -- ^ Remove socket address copied from 'Config'.
+    , auxSendInformational :: H.Status -> H.ResponseHeaders -> IO ()
+    -- ^ Send an informational (1xx) response, e.g. 103 Early Hints, on this
+    --   request's stream before the final response. May be called multiple
+    --   times. A no-op in 'defaultAux'.
     }

--- a/http-semantics.cabal
+++ b/http-semantics.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            http-semantics
-version:         0.4.0
+version:         0.4.1
 license:         BSD-3-Clause
 license-file:    LICENSE
 maintainer:      Kazu Yamamoto <kazu@iij.ad.jp>


### PR DESCRIPTION
This is the first step of a plan I'm working on to support HTTP early hints in WAI/Warp and associated libraries.

We initially talked about this in https://github.com/yesodweb/wai/issues/970 and now I'm hoping to do it properly.

Follow-on PRs:
* https://github.com/kazu-yamamoto/http2/pull/168
